### PR TITLE
[#6] IssueDetail 페이지에서 사용할 프로필 Avartar 컴포넌트 구현

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,7 @@
-// Layout Components'
+// Layout Components
 export { default as Layout } from './layout';
 export { default as Header } from './layout/Header';
+
+// Shared Components
+export { default as Avatar } from './shared/Avatar';
+export { default as Anchor } from './shared/Anchor';

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,5 +1,5 @@
 import * as S from './styled';
 
 export default function Header() {
-	return <div>Header</div>;
+	return <></>;
 }

--- a/src/components/shared/Anchor/index.tsx
+++ b/src/components/shared/Anchor/index.tsx
@@ -1,0 +1,11 @@
+import * as S from './styled';
+import { PropsWithChildren } from 'react';
+
+type Props = {
+	href?: string;
+	target: '_blank' | '_self' | '_parent' | '_top';
+} & PropsWithChildren;
+
+export default function Anchor({ children, ...props }: Props) {
+	return <S.Anchor {...props}>{children}</S.Anchor>;
+}

--- a/src/components/shared/Anchor/styled.ts
+++ b/src/components/shared/Anchor/styled.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Anchor = styled.a`
+	display: flex;
+	height: 100%;
+`;

--- a/src/components/shared/Avatar/index.tsx
+++ b/src/components/shared/Avatar/index.tsx
@@ -1,0 +1,18 @@
+import * as S from './styled';
+import Anchor from '../Anchor';
+
+type Props = {
+	imgSrc?: string;
+	href?: string;
+	borderRadius?: string;
+};
+
+export default function Avartar(props: Props) {
+	return (
+		<Anchor href={props.href} target="_blank">
+			<S.AvatarContainer>
+				<S.AvatarImage src={props.imgSrc ?? '/logo.png'} alt="프로필" borderRadius={props.borderRadius} />
+			</S.AvatarContainer>
+		</Anchor>
+	);
+}

--- a/src/components/shared/Avatar/styled.ts
+++ b/src/components/shared/Avatar/styled.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+type AvatarProps = {
+	borderRadius?: string;
+};
+
+export const AvatarContainer = styled.div`
+	display: flex;
+`;
+
+export const AvatarImage = styled.img<AvatarProps>`
+	border-radius: ${({ borderRadius }) => borderRadius && borderRadius};
+`;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,19 +1,31 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import styled from 'styled-components';
+import { Avatar } from '../components';
 import { checkArray } from '../utils/checkArray';
-
 import ROUTE_PATH from './routePath';
 
 export default function Router() {
 	const routeList = [
 		{
+			id: 1,
 			path: ROUTE_PATH.MAIN,
 			element: <div>메인 페이지</div>,
 		},
 		{
+			id: 2,
 			path: ROUTE_PATH.DETAIL,
-			element: <div>상세 페이지</div>,
+			element: (
+				<Div>
+					<Avatar
+						href="https://github.com/youngminss/"
+						imgSrc="https://avatars.githubusercontent.com/u/50790145?v=4"
+						borderRadius="50%"
+					/>
+				</Div>
+			),
 		},
 		{
+			id: 3,
 			path: ROUTE_PATH.ERROR,
 			element: <div>에러 페이지</div>,
 		},
@@ -23,10 +35,14 @@ export default function Router() {
 		<BrowserRouter>
 			<Routes>
 				{checkArray(routeList) &&
-					routeList.map(({ path, element }) => {
-						return <Route path={path} element={element} />;
+					routeList.map(({ id, path, element }) => {
+						return <Route key={id} path={path} element={element} />;
 					})}
 			</Routes>
 		</BrowserRouter>
 	);
 }
+
+const Div = styled.div`
+	height: 80px;
+`;


### PR DESCRIPTION
## 해결한 이슈

- #6 

<br />

## 해결 방법

`링크 Avartar 컴포넌트 UI`

- 정의한 UI 요구사항 상에서는 `IssueDetail` 페이지에서 상단 Author(Issue 작성자) 정보에만 노출이 됩니다.
  
  - 이 프로필 이미지를 누르면, 해당 Author 의 깃헙 프로필 페이지로 이동하도록 구현해야 했고, 이를 위해 `Anchor 컴포넌트` 를 공통 컴포넌트로 구현하고 Avartar 컴포넌트 Container 로 사용햇습니다.

- Avartar 컴포넌트의 크기는 동적으로 설정할 수 있도록 해당 컴포넌트를 감싸고 있는 컨테이너 높이에 영향을 받도록 설정했습니다. 또한 borderRadius 속성을 props 로 전달해서 꼭 원형 Avartar 가 아닌 다른 모양으로 표현 가능토록 설계해서 구현했습니다.
 

<br />

## 캡처 첨부

`Avartar 컴포넌트 - 컨테이너 height 가 80px 인 경우`

<img width="433" alt="image" src="https://user-images.githubusercontent.com/50790145/198875803-f6a288c7-a7a3-4bd8-b8d0-e669e3ba41c4.png">


`Avartar 컴포넌트 - 컨테이너 height 가 200px 인 경우`

<img width="426" alt="image" src="https://user-images.githubusercontent.com/50790145/198875135-50fe2d81-0ace-4963-bc9c-a3a17213e0b8.png">


<br />

## 추가적인 태스크

- 만약, `IssueList` 의 각 IssueItem 에도 Author 프로필 Avatar 가 보여야 되는 상황이 필요하다면, 그때의 Avatar 는 링크 이동이 필요 없을 수 있으므로, 일반 Avartar 컴포넌트와 링크 Avartar 로 분리가 필요해 보임. 

<br />
<br />

## P.S

![image](https://user-images.githubusercontent.com/50790145/198876020-2a93991b-403f-4bec-a646-97f90da22119.png)

@od-log `routerList` 배열에 대해 map 함수로 라우터 컴포넌트 렌더링 할때 key 값을 설정하지 않아서 리액트에서 에러를 발생시켰고, 이를 해결하기 위해서 routerList 의 각 요소에 대해 id 프로퍼티를 추가해서 map 함수 사용시 key 값으로 사용했습니다.

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
