### PR TITLE
[#5] 타이틀 컴포넌트 구현

### DIFF
--- a/src/shared/Title/index.tsx
+++ b/src/shared/Title/index.tsx
@@ -1,0 +1,11 @@
+import { CSSProperties } from 'styled-components';
+import { TitleLayout } from './styled';
+
+type Props = {
+	children: string;
+	style?: CSSProperties;
+};
+
+export default function Title({ children, ...style }: Props) {
+	return <TitleLayout {...style}>{children}</TitleLayout>;
+}

--- a/src/shared/Title/styled.ts
+++ b/src/shared/Title/styled.ts
@@ -1,0 +1,5 @@
+import styled, { CSSProperties } from 'styled-components';
+
+export const TitleLayout = styled.section((props: CSSProperties) => ({
+	...props,
+}));


### PR DESCRIPTION
## 해결한 이슈

- #5 

<br />

## 해결 방법

해결 이슈 제목 1 - 이슈 헤더 타이틀과 이슈 목록 타이틀에서 사용 가능한 공통 타이틀 컴포넌트 구현

- 여러 화면에서 공유 가능한 타이틀 컴포넌트를 구현했습니다.
- 자유롭게 스타일을 변경할 수 있도록 style을 props로 받아서 styled-components 파일에서 스타일을 받아서 적용할 수 있게 구현했습니다.

<br />

## 캡처 첨부

관련 이슈 제목 1

- 내용을 입력해주세요.

<br />

## 추가적인 태스크

- 미디어 쿼리가 필요한 경우 스타일 적용 방법은 고민이 필요합니다....

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
