### PR TITLE
[#29] IssueDetail에 사용할 IssueHeader 컴포넌트 구현

### DIFF
--- a/src/apis/Issue.ts
+++ b/src/apis/Issue.ts
@@ -6,3 +6,9 @@ export const getIssues = async () => {
 	});
 	return res.data;
 };
+
+export function getDetailIssues(number: string) {
+	return axios.get(`https://api.github.com/repos/angular/angular-cli/issues/${number}`, {
+		headers: { Authorization: `token ${import.meta.env.VITE_API_KEY}` },
+	});
+}

--- a/src/components/feature/Issue/index.tsx
+++ b/src/components/feature/Issue/index.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
 
 import CommonTitle from '../../../shared/Title';
-import { IssueWriter, IssueComment, IssueTime, IssueNumber } from '../../';
+import { IssueWriter, IssueNumber, IssueTime, IssueComment } from '../../';
 import { IssueLayout, BorderLine } from './styled';
+import { useNavigate } from 'react-router-dom';
 
 export default function Issue({ issueItem, userItem }: any) {
+	const navigate = useNavigate();
 	const style = {};
 	const { comments, number, title, created_at, updated_at } = issueItem;
 	const { login, html_url, avatar_url } = userItem;
 
 	return (
 		<IssueLayout>
-			<div className="title">
+			<div
+				className="title"
+				onClick={() => {
+					navigate(`/detail/${number}`);
+				}}
+			>
 				<CommonTitle style={style}>
 					{title}
 					<IssueNumber issueNumber={number} />

--- a/src/components/feature/IssueHeader/index.tsx
+++ b/src/components/feature/IssueHeader/index.tsx
@@ -1,0 +1,41 @@
+import Avartar from '../../shared/Avatar';
+import CommonTitle from '../../../shared/Title';
+import { IssueWriter, IssueNumber, IssueTime, IssueComment } from '../../';
+import { BorderLine, IssueDetailWrapper } from './styled';
+
+export type IssueItem = {
+	number: number;
+	title: string;
+	created_at: string;
+	comments: number;
+	login: string;
+	body: string;
+	user?: UserItem;
+};
+
+export type UserItem = {
+	login: string;
+	avatar_url: string;
+};
+
+export default function IssueHeader(props: IssueItem) {
+	return (
+		<IssueDetailWrapper>
+			<div className="userInfo">
+				<Avartar imgSrc={props.avatar_url} />
+				<div className="writeInfo">
+					<IssueWriter writerName={props.login} />
+					<IssueTime writeTime={props.created_at} />
+				</div>
+			</div>
+			<div className="issueInfo">
+				<div>
+					<CommonTitle style={{ fontSize: '1.5rem' }}>{props.title}</CommonTitle>
+					<IssueNumber issueNumber={props.number} />
+				</div>
+				<IssueComment commentCount={props.comments} />
+			</div>
+			<BorderLine />
+		</IssueDetailWrapper>
+	);
+}

--- a/src/components/feature/IssueHeader/styled.ts
+++ b/src/components/feature/IssueHeader/styled.ts
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+
+export const IssueDetailWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	max-width: 100vw;
+	.userInfo {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		margin-bottom: 1rem;
+		gap: 7px;
+		div {
+			img {
+				width: 5rem;
+			}
+		}
+		@media ${({ theme }) => theme.device.laptop} {
+			gap: 12px;
+		}
+		font-size: ${({ theme }) => theme.fontSizes.normal};
+		@media ${({ theme }) => theme.device.laptop} {
+			font-size: ${({ theme }) => theme.fontSizes.large};
+		}
+		.writeInfo {
+			display: flex;
+			flex-direction: column;
+			padding-top: 1rem;
+			div {
+				display: flex;
+				flex-direction: row;
+			}
+			p {
+				margin-left: 1rem;
+				margin-bottom: 1rem;
+			}
+		}
+	}
+	.issueInfo {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+	}
+`;
+
+export const BorderLine = styled.div`
+	height: 1px;
+	background: #000000;
+	margin: 10px 0;
+	@media ${({ theme }) => theme.device.laptop} {
+		margin: 20px 0;
+	}
+`;

--- a/src/pages/IssueDetail/index.tsx
+++ b/src/pages/IssueDetail/index.tsx
@@ -1,24 +1,45 @@
-import { Avatar, IssueComment, IssueNumber, IssueTime, IssueWriter } from '../../components';
-import { BorderLine } from '../../components/feature/Issue/styled';
-import Title from '../../shared/Title';
+import { useEffect, useState } from 'react';
+import { Params, useParams } from 'react-router-dom';
+import IssueHeader, { IssueItem } from '../../components/feature/IssueHeader';
 import { DetailLayout } from './styled';
+import { getDetailIssues } from '../../apis/Issue';
+import { AxiosResponse } from 'axios';
 
 export default function IssueDetail() {
-	const html_url = 'https://github.com/youngminss/';
-	const avartar_url = 'https://avatars.githubusercontent.com/u/50790145?v=4';
-	const writerName = 'writerName';
-	const issueTime = '2022-10-28T19:15:35Z';
-	const issueNumber = 112233;
+	const { issueNumber } = useParams<Params>();
+	const [issueData, setIssueData] = useState<IssueItem>();
+
+	console.log(issueData);
+
+	const getDetail = async (issueNumber: string) => {
+		let res: AxiosResponse;
+		try {
+			res = await getDetailIssues(issueNumber);
+			setIssueData(res.data);
+		} catch (err) {
+			alert(err);
+		}
+	};
+
+	useEffect(() => {
+		if (issueNumber) {
+			getDetail(issueNumber);
+		}
+	}, []);
+
 	return (
 		<DetailLayout>
-			<Avatar href={html_url} imgSrc={avartar_url} borderRadius="50%" />
-			<IssueWriter writerName={writerName} />
-			<IssueTime writeTime={issueTime} />
-			<Title>css 적용이 안되는 문제.......</Title>
-			<IssueNumber issueNumber={issueNumber} />
-			<IssueComment commentCount={121} />
-			<BorderLine />
-			{/* <IssueBody/> */}
+			{issueData && (
+				<IssueHeader
+					number={issueData.number}
+					title={issueData.title}
+					created_at={issueData.created_at}
+					login={issueData.user.login}
+					avatar_url={issueData.user.avatar_url}
+					comments={issueData.comments}
+					body={issueData.body}
+				/>
+			)}
 		</DetailLayout>
 	);
 }

--- a/src/router/routePath.ts
+++ b/src/router/routePath.ts
@@ -4,7 +4,7 @@ type PATH = Record<Pages, string>;
 
 const ROUTE_PATH: PATH = {
 	MAIN: '/',
-	DETAIL: '/detail',
+	DETAIL: '/detail/:issueNumber',
 	ERROR: '*',
 };
 


### PR DESCRIPTION
## 해결한 이슈

- #29 

<br />

## 해결 방법

- 상세페이지 요구 사항에서 본문과 헤더부분을 분리하고, 헤더부분에 필요한 ‘이슈번호, 이슈제목, 작성자, 작성일, 코멘트 수, 작성자 프로필 이미지' 표시되게 구현하였습니다.

<br />

## 캡처 첨부

<img width="1230" alt="스크린샷 2022-10-31 오전 7 56 14" src="https://user-images.githubusercontent.com/108744804/198905823-314657a6-8ee7-4b3a-a37f-a2ad0ee9b1aa.png">


<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
